### PR TITLE
분류모델 경로재설정, step return 추가

### DIFF
--- a/webrtc/ai/OZEngine/dress_checkers/NavyServiceUniformChecker.py
+++ b/webrtc/ai/OZEngine/dress_checkers/NavyServiceUniformChecker.py
@@ -101,5 +101,4 @@ class NavyServiceUniformChecker(UniformChecker):
                     component_dic['class_tag'] = component
                     masked_img_dic['class_tag'] = masked_img
 
-        print('debug cnt : ', self.debug_cnt)
         return component_dic, box_position_dic, masked_img_dic

--- a/webrtc/ai/OZEngine/dress_checkers/NavyServiceUniformChecker.py
+++ b/webrtc/ai/OZEngine/dress_checkers/NavyServiceUniformChecker.py
@@ -24,6 +24,8 @@ class NavyServiceUniformChecker(UniformChecker):
         self.name_cache = None
         self.debug_cnt = 0
 
+        self.result_dic = {'component':{}, 'box_position':{}, 'masked_img':{}, 'probability':{}}
+
 
     def isNameTag(self, contour, position, kind):
         return position == 'left' and kind == 'name_tag'
@@ -39,19 +41,15 @@ class NavyServiceUniformChecker(UniformChecker):
         img = org_img
         hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
         H, W = img.shape[: 2]
-
-        box_position_dic = {}
-        component_dic = {}
-        masked_img_dic = {}
-
+        
         # 샘당 filter
-        contours, hierarchy, masked_img_dic['shirt'] = self.getMaskedContours(
+        contours, hierarchy, self.result_dic['masked_img']['shirt'] = self.getMaskedContours(
             img=img, hsv_img=hsv_img, kind='uniform', sort=True)
 
         # 이름표, 계급장 체크
         for i, (contour, lev) in enumerate(zip(contours, hierarchy)):
-            is_class_tag = component_dic.get('class_tag')
-            is_name_tag = component_dic.get('name_tag')
+            is_class_tag = result_dic['component'].get('class_tag')
+            is_name_tag = result_dic['component'].get('name_tag')
 
             if is_name_tag and is_class_tag:
                 break
@@ -88,8 +86,8 @@ class NavyServiceUniformChecker(UniformChecker):
                         self.name_cache = component
 
                     # return값에 반영
-                    box_position_dic['name_tag'] = box_position
-                    component_dic['name_tag'] = component
+                    self.result_dic['box_position']['name_tag'] = box_position
+                    self.result_dic['component']['name_tag'] = component
 
                 # 계급장 체크
                 elif not is_class_tag and self.isClassTag(contour, position, kind):
@@ -97,8 +95,8 @@ class NavyServiceUniformChecker(UniformChecker):
                         img, hsv_img, contour)
 
                     # return값에 반영
-                    box_position_dic['class_tag'] = box_position
-                    component_dic['class_tag'] = component
-                    masked_img_dic['class_tag'] = masked_img
+                    self.result_dic['box_position']['class_tag'] = box_position
+                    self.result_dic['component']['class_tag'] = component
+                    self.result_dic['masked_img']['class_tag'] = masked_img
 
-        return component_dic, box_position_dic, masked_img_dic
+        return result_dic

--- a/webrtc/ai/OZEngine/dress_classifier/DressClassifier.py
+++ b/webrtc/ai/OZEngine/dress_classifier/DressClassifier.py
@@ -5,7 +5,7 @@ from OZEngine.lib.defines import UniformType
 
 class DressClassifier(FeatureExtractor):
     def __init__(self):
-        project_path = '/config/workspace/WEB_CLOUD_OmilZomil_NAVYeffect/webrtc/ai/OZEngine/dress_classifier'
+        project_path = os.path.join(os.environ['AI_PATH'], 'OZEngine', 'dress_classifier')
         base_url = os.path.join(project_path, 'Dress')
         super().__init__(base_url)
 

--- a/webrtc/ai/OZEngine/model.py
+++ b/webrtc/ai/OZEngine/model.py
@@ -90,7 +90,7 @@ class OmilZomil:
         if self.check_person:
             person_box = self.person_detector.detect(img)
             if person_box is None:
-                return {}
+                return {'step':0}
             img = box2img(img, person_box)
             self.addBasePoint(person_box)
         
@@ -99,9 +99,9 @@ class OmilZomil:
         face_box = self.face_detector.detect(img)
         if face_box is None:
             if self.hed_mode:
-                return {'boxed_img':org_img, 'hed_boxed_img':hed_boxed_img}
+                return {'step':1, 'boxed_img':org_img, 'hed_boxed_img':hed_boxed_img}
             else:
-                return {'boxed_img':org_img}
+                return {'step':1, 'boxed_img':org_img}
 
         x,y,w,h = cvtPoint(face_box, method='2to4')
         y += person_box[0][0]
@@ -127,7 +127,7 @@ class OmilZomil:
             elif self.uniform_type == UniformType.dic['FULL_DRESS']:
                 self.uniform_checker = FullDressUniformChecker(self.train_mode)
             else:
-                return None
+                return {'step':2, 'boxed_img':org_img}
 
         # 복장검사모델
         result_dic = self.uniform_checker.checkUniform(shirt_img)
@@ -142,6 +142,6 @@ class OmilZomil:
             hed_boxed_img, _ = self.boxImage(hed_boxed_img, result_dic)
 
         if self.hed_mode:
-            return {'boxed_img':boxed_img, 'hed_boxed_img': hed_boxed_img, 'component':result_dic['component'], 'roi':roi_dic}
+            return {'step':3, 'boxed_img':boxed_img, 'hed_boxed_img': hed_boxed_img, 'component':result_dic['component'], 'roi':roi_dic}
         else:
-            return {'boxed_img':boxed_img, 'component':result_dic['component'], 'roi':roi_dic}
+            return {'step':3, 'boxed_img':boxed_img, 'component':result_dic['component'], 'roi':roi_dic}

--- a/webrtc/ai/OZEngine/parts_classifier/PartsClassifier.py
+++ b/webrtc/ai/OZEngine/parts_classifier/PartsClassifier.py
@@ -8,7 +8,7 @@ def distFunc(x):
     return -0.6*x + 1
 class PartsClassifier(FeatureExtractor):
     def __init__(self, dress_kind):
-        project_path = '/config/workspace/WEB_CLOUD_OmilZomil_NAVYeffect/webrtc/ai/OZEngine/parts_classifier'
+        project_path = os.path.join(os.environ['AI_PATH'], 'OZEngine', 'parts_classifier')
         if dress_kind == 'navy_service_uniform':
             base_url = os.path.join(project_path, 'NavyServiceUniform')
         elif dress_kind == 'full_dress_uniform':


### PR DESCRIPTION
분류모델에 경로가 절대경로로 되어있는 에러 수정
WEBRTC에서도 AI처리 step을 알 수 있도록 step을 integer로 지정하여 return

return된 각 step의 의미:

0. 사람인식이 실패
1. 얼굴인식이 실패  (사람인식까지는 된 상태)
2. 복장인식이 실패  (얼굴인식까지는 된 상태)
3. 파츠인식이 실패  (복장인식까지는 된 상태) - 또는 사용자가 아무 파츠도 착용하지 않은 상태일 수도 있다